### PR TITLE
Bugfixes to tf-singularity Recipe

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,13 @@
 IMG="tf-gpu.img"
 DEF="tf-gpu.def"
+echo "Removing old image file"
 sudo rm -f $IMG
+echo "Creating new image file"
 sudo singularity create -s 4000 $IMG
+echo "Bootstrapping image using docker"
 sudo singularity bootstrap $IMG $DEF
+echo "Executing tensorflow.sh to install NVIDIA/CUDA/CuDNN"
 sudo singularity exec -B `pwd`:/mnt -w $IMG sh /mnt/tensorflow.sh 
+echo "Executing sherlock.sh to prepare for Sherlock environment"
 sudo singularity exec  -B `pwd`:/mnt -w $IMG sh /mnt/sherlock.sh
+echo "Exiting build.sh"

--- a/sherlock.sh
+++ b/sherlock.sh
@@ -1,5 +1,6 @@
 # Because sherlock doesn't enable singularity overlay, we must create these
 # before moving container to sherlock.
+echo "About to make directories needed on sherlock"
 mkdir -p /share/PI
 mkdir -p /scratch
 mkdir -p /local-scratch

--- a/tensorflow.sh
+++ b/tensorflow.sh
@@ -1,14 +1,22 @@
-driver_version=367.48
-cuda="cuda-linux64-rel-8.0.44-21122537.run"
-cudnn="cudnn-8.0-linux-x64-v5.1.tar"
+driver_version=367.44
+cuda="cuda_8.0.44_linux.run"
+cudnn="cudnn-8.0-linux-x64-v5.1.tgz"
+echo "About to execute driver run file"
 sh /mnt/NVIDIA-Linux-x86_64-$driver_version.run -x
+echo "Moving generated driver executable to /usr/local"
 mv NVIDIA-Linux-x86_64-$driver_version /usr/local/
+echo "About to execute linking file"
 sh /mnt/links.sh $driver_version
 
+echo "About to execute cuda run file"
 sh /mnt/$cuda  --toolkit --noprompt
+echo "Unpacking cudnn files to /usr/local"
 tar xvf /mnt/$cudnn -C /usr/local
 
+echo "Adding paths to /environment"
 driver_path=/usr/local/NVIDIA-Linux-x86_64-$driver_version
+# Add newline before appending to /environment file
+echo " " >> /environment
 echo "LD_LIBRARY_PATH=/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:$driver_path:$LD_LIBRARY_PATH" >> /environment
 echo "PATH=$driver_path:\$PATH" >> /environment
 echo "export PATH LD_LIBRARY_PATH" >> /environment

--- a/tensorflow.sh
+++ b/tensorflow.sh
@@ -1,5 +1,5 @@
-driver_version=367.44
-cuda="cuda_8.0.44_linux.run"
+driver_version=367.48
+cuda="cuda_linux64-rel-8.0.44-21122537.run"
 cudnn="cudnn-8.0-linux-x64-v5.1.tgz"
 echo "About to execute driver run file"
 sh /mnt/NVIDIA-Linux-x86_64-$driver_version.run -x

--- a/tensorflow.sh
+++ b/tensorflow.sh
@@ -1,5 +1,5 @@
 driver_version=367.48
-cuda="cuda_linux64-rel-8.0.44-21122537.run"
+cuda="cuda-linux64-rel-8.0.44-21122537.run"
 cudnn="cudnn-8.0-linux-x64-v5.1.tgz"
 echo "About to execute driver run file"
 sh /mnt/NVIDIA-Linux-x86_64-$driver_version.run -x

--- a/tf-gpu.def
+++ b/tf-gpu.def
@@ -4,7 +4,7 @@
 # through Lawrence Berkeley National Laboratory (subject to receipt of any
 # required approvals from the U.S. Dept. of Energy).  All rights reserved.
 
-Bootstrap: docker
+BootStrap: docker
 From: tensorflow/tensorflow:0.11.0rc2-gpu 
 IncludeCmd: yes
 


### PR DESCRIPTION
I had to make a couple bugfixes to the recipe to get it working for me. Bundling up into a PR in case might be useful to other folks. Quick summary of changes in this PR:

- `s/Bootstrap/BootStrap/` in `tf-gpu.def` (I think was a typo previously)
-  Add a newline to "/environment" before appending new paths (was breaking the `if` statement in `/environment` for me otherwise).
- I couldn't find NVIDIA driver version 367.48 on NVIDIA's download page. Substituted for 367.44 (hoping this doesn't cause errors)
- Added a number of `echo` statements to help keep track of what `build.sh` is doing.